### PR TITLE
Made Webcam.reset() idempotent

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -178,10 +178,10 @@ var Webcam = {
 			delete this.video;
 		}
 		
-        if (this.container) {
-          this.container.innerHTML = '';
-          delete this.container;
-        }
+		if (this.container) {
+			this.container.innerHTML = '';
+			delete this.container;
+		}
 	
 		this.loaded = false;
 		this.live = false;

--- a/webcam.js
+++ b/webcam.js
@@ -178,9 +178,11 @@ var Webcam = {
 			delete this.video;
 		}
 		
-		this.container.innerHTML = '';
-		delete this.container;
-		
+        if (this.container) {
+          this.container.innerHTML = '';
+          delete this.container;
+        }
+	
 		this.loaded = false;
 		this.live = false;
 	},


### PR DESCRIPTION
So it's safe to call it several times without errors. Also safe to call without calling initializing Webcam itself, which is what I'm doing. 

Use case here is that Webcam is used within a dialog and once that dialog closes I want the Webcam to reset, but not all dialogs use Webcam.