### PR TITLE
Check if innerHTML is safe

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -178,7 +178,9 @@ var Webcam = {
 			delete this.video;
 		}
 		
-		this.container.innerHTML = '';
+		if (this.container && this.container.innerHTML) {
+		        this.container.innerHTML = '';
+		}
 		delete this.container;
 		
 		this.loaded = false;


### PR DESCRIPTION
IE11 complained: "Unable to set property 'innerHTML' of undefined or null reference"