### PR TITLE
What about including this project into the cdnjs project ?

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "webcamjs",
+  "version": "1.0.2",
+  "description": "WebcamJS is a small (~3K minified and gzipped) standalone JavaScript library for capturing still images from your computer's camera, and delivering them to you as JPEG or PNG Data URIs. The images can then be displayed in your web page, rendered into a canvas, or submitted to your server. WebcamJS uses HTML5 getUserMedia, but provides an automatic and invisible Adobe Flash fallback.",
+  "filename": "webcam.min.js",
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/Jeni4/webcamjs.git",
+    "basePath": "",
+    "files": [
+      "webcam.min.js",
+      "webcam.swf"
+    ]
+  },
+  "homepage": "https://github.com/jhuckaby/webcamjs",
+  "repository": [
+    {
+      "type": "git",
+      "url": "https://github.com/jhuckaby/webcamjs.git"
+    }
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "filename": "webcam.min.js",
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/Jeni4/webcamjs.git",
+    "target": "git://github.com/jhuckaby/webcamjs.git",
     "basePath": "",
     "files": [
+	  "webcam.js"
       "webcam.min.js",
       "webcam.swf"
     ]

--- a/package.json
+++ b/package.json
@@ -13,12 +13,16 @@
       "webcam.swf"
     ]
   },
-  "homepage": "https://github.com/jhuckaby/webcamjs",
+  "homepage": "http://pixlcore.com/read/WebcamJS",
   "repository": [
     {
       "type": "git",
       "url": "https://github.com/jhuckaby/webcamjs.git"
     }
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "webcam"
+  ],
+  "author": "Joseph Huckaby"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "target": "git://github.com/jhuckaby/webcamjs.git",
     "basePath": "",
     "files": [
-	  "webcam.js"
+	  "webcam.js",
       "webcam.min.js",
       "webcam.swf"
     ]


### PR DESCRIPTION
I have created a package.json file per the cdnjs project description, and will suggest it included in your project, so when you in the future bumps the version number in (1) the webcam.js script and (2) the package.json file, the cdnjs repo should auto import the new version into their repo and make it available on https://cdnjs.com... What do you say?