### PR TITLE
MediaStream `stop()` is deprecated

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -179,7 +179,7 @@ var Webcam = {
 		this.unflip();
 		
 		if (this.userMedia) {
-			try { this.stream.stop(); } catch (e) {;}
+			try { this.stream.getTracks()[0].stop(); } catch (e) {;}
 			delete this.stream;
 			delete this.video;
 		}


### PR DESCRIPTION
Use MediaStreamTrack `stop()` instead of MediaStream `stop()`.

https://developers.google.com/web/updates/2015/07/mediastream-deprecations