### PR TITLE
Return errors directly rather than strings

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -9,6 +9,30 @@
 (function(window) {
 var _userMedia;
 
+// declare error types
+
+// inheritance pattern here:
+// https://stackoverflow.com/questions/783818/how-do-i-create-a-custom-error-in-javascript
+function FlashError() {
+	var temp = Error.apply(this, arguments);
+	temp.name = this.name = "FlashError";
+	this.stack = temp.stack;
+	this.message = temp.message;
+}
+
+function WebcamError() {
+	var temp = Error.apply(this, arguments);
+	temp.name = this.name = "WebcamError";
+	this.stack = temp.stack;
+	this.message = temp.message;
+}
+
+IntermediateInheritor = function() {};
+IntermediateInheritor.prototype = Error.prototype;
+
+FlashError.prototype = new IntermediateInheritor();
+WebcamError.prototype = new IntermediateInheritor();
+
 var Webcam = {
 	version: '1.0.6',
 	
@@ -32,6 +56,11 @@ var Webcam = {
 		constraints: null,     // custom user media constraints,
 		swfURL: '',            // URI to webcam.swf movie (defaults to the js location)
 		flashNotDetectedText: 'ERROR: No Adobe Flash Player detected.  Webcam.js relies on Flash for browsers that do not support getUserMedia (like yours).'
+	},
+
+	errors: {
+		FlashError: FlashError,
+		WebcamError: WebcamError
 	},
 	
 	hooks: {}, // callback hook functions
@@ -75,7 +104,7 @@ var Webcam = {
 			elem = document.getElementById(elem) || document.querySelector(elem);
 		}
 		if (!elem) {
-			return this.dispatch('error', "Could not locate DOM element to attach to.");
+			return this.dispatch('error', new WebcamError("Could not locate DOM element to attach to."));
 		}
 		this.container = elem;
 		elem.innerHTML = ''; // start with empty element
@@ -154,7 +183,7 @@ var Webcam = {
 				self.flip();
 			})
 			.catch( function(err) {
-				return self.dispatch('error', "Could not access webcam: " + err.name + ": " + err.message, err);
+				return self.dispatch('error', err);
 			});
 		}
 		else {
@@ -332,13 +361,13 @@ var Webcam = {
 		
 		// make sure we aren't running locally (flash doesn't work)
 		if (location.protocol.match(/file/)) {
-			this.dispatch('error', "Flash does not work from local disk.  Please run from a web server.");
+			this.dispatch('error', new FlashError("Flash does not work from local disk.  Please run from a web server."));
 			return '<h3 style="color:red">ERROR: the Webcam.js Flash fallback does not work from local disk.  Please run it from a web server.</h3>';
 		}
 		
 		// make sure we have flash
 		if (!this.detectFlash()) {
-			this.dispatch('error', "Adobe Flash Player not found.  Please install from get.adobe.com/flashplayer and try again.");
+			this.dispatch('error', new FlashError("Adobe Flash Player not found.  Please install from get.adobe.com/flashplayer and try again."));
 			return '<h3 style="color:red">' + this.params.flashNotDetectedText + '</h3>';
 		}
 		
@@ -379,10 +408,10 @@ var Webcam = {
 	
 	getMovie: function() {
 		// get reference to movie object/embed in DOM
-		if (!this.loaded) return this.dispatch('error', "Flash Movie is not loaded yet");
+		if (!this.loaded) return this.dispatch('error', new FlashError("Flash Movie is not loaded yet"));
 		var movie = document.getElementById('webcam_movie_obj');
 		if (!movie || !movie._snap) movie = document.getElementById('webcam_movie_embed');
-		if (!movie) this.dispatch('error', "Cannot locate Flash movie in DOM");
+		if (!movie) this.dispatch('error', new FlashError("Cannot locate Flash movie in DOM"));
 		return movie;
 	},
 	
@@ -517,9 +546,9 @@ var Webcam = {
 		var self = this;
 		var params = this.params;
 		
-		if (!this.loaded) return this.dispatch('error', "Webcam is not loaded yet");
-		// if (!this.live) return this.dispatch('error', "Webcam is not live yet");
-		if (!user_callback) return this.dispatch('error', "Please provide a callback function or canvas to snap()");
+		if (!this.loaded) return this.dispatch('error', new WebcamError("Webcam is not loaded yet"));
+		// if (!this.live) return this.dispatch('error', new WebcamError("Webcam is not live yet"));
+		if (!user_callback) return this.dispatch('error', new WebcamError("Please provide a callback function or canvas to snap()"));
 		
 		// if we have an active preview freeze, use that
 		if (this.preview_active) {
@@ -629,7 +658,7 @@ var Webcam = {
 
 			case 'error':
 				// Flash error
-				this.dispatch('error', msg);
+				this.dispatch('error', new FlashError(msg));
 				break;
 
 			default:

--- a/webcam.js
+++ b/webcam.js
@@ -311,8 +311,15 @@ var Webcam = {
 			return true;
 		}
 		else if (name == 'error') {
+			if ((args[0] instanceof FlashError) || (args[0] instanceof WebcamError)) {
+				message = args[0].message;
+			} else {
+				message = "Could not access webcam: " + err.name + ": " + 
+					err.message + " " + err.toString();
+			}
+
 			// default error handler if no custom one specified
-			alert("Webcam.js Error: " + args[0]);
+			alert("Webcam.js Error: " + message);
 		}
 		
 		return false; // no hook defined


### PR DESCRIPTION
Addresses #111. Returns all errors currently returned as strings wrapped in error types; passes through errors outputted by called libraries rather than interpreting them as a string.

**Note**: this breaks backwards compatibility for clients that interpret the errors as strings; if you care about retaining that, we can throw the error response behavior behind a flag.

### Relevant links

* [Production practices in Node: use error objects for all errors](https://www.joyent.com/developers/node/design/errors#2-use--code-error--code--objects-or-subclasses-for-all-errors-and-implement-the--code-error--code--contract)