### PR TITLE
Keep Preview Frozen - on calling "SNAP"

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -531,7 +531,7 @@ var Webcam = {
 		}
 	},
 	
-	savePreview: function(user_callback, user_canvas) {
+	savePreview: function(user_callback, user_canvas, keepfrozen) {
 		// save preview freeze and fire user callback
 		var params = this.params;
 		var canvas = this.preview_canvas;
@@ -550,11 +550,13 @@ var Webcam = {
 			context
 		);
 		
-		// remove preview
-		this.unfreeze();
+		if(!keepfrozen) {
+			// remove preview
+			this.unfreeze();
+		}
 	},
 	
-	snap: function(user_callback, user_canvas) {
+	snap: function(user_callback, user_canvas, keepFrozen) {
 		// take snapshot and return image data uri
 		var self = this;
 		var params = this.params;
@@ -565,7 +567,7 @@ var Webcam = {
 		
 		// if we have an active preview freeze, use that
 		if (this.preview_active) {
-			this.savePreview( user_callback, user_canvas );
+			this.savePreview( user_callback, user_canvas, keepFrozen );
 			return null;
 		}
 		


### PR DESCRIPTION
i needed the preview to stay frozen - after taking snap.
added the parameter to `savePreview` and `snap`


now i can call

```
Webcam.snap(function(){}, null, true);
```


