### PR TITLE
Add var statement to IntermediateInheritor

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -27,7 +27,7 @@ function WebcamError() {
 	this.message = temp.message;
 }
 
-IntermediateInheritor = function() {};
+var IntermediateInheritor = function() {};
 IntermediateInheritor.prototype = Error.prototype;
 
 FlashError.prototype = new IntermediateInheritor();


### PR DESCRIPTION
Without "var" it throws an error "Uncaught ReferenceError: IntermediateInheritor is not defined" in ionic2 RC1