### PR TITLE
Add X-Requested-With header for some backend recognizing it as an ajax request

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -993,6 +993,7 @@ var Webcam = {
 		// contruct use AJAX object
 		var http = new XMLHttpRequest();
 		http.open("POST", target_url, true);
+		http.setRequestHeader("X-Requested-With", "XMLHttpRequest");
 		
 		// setup progress events
 		if (http.upload && http.upload.addEventListener) {


### PR DESCRIPTION
In Laravel and Symfony, in example, this header is used to check whether the request is an ajax.