### PR TITLE
Make webcam js work in Safari

### DIFF
--- a/webcam.js
+++ b/webcam.js
@@ -316,7 +316,15 @@ var Webcam = {
 					self.dispatch('live');
 					self.flip();
 				};
-				video.src = window.URL.createObjectURL( stream ) || stream;
+				// as window.URL.createObjectURL() is deprecated, adding a check so that it works in Safari.
+				// older browsers may not have srcObject
+				if ("srcObject" in video) {
+				  	video.srcObject = stream;
+				}
+				else {
+				  	// using URL.createObjectURL() as fallback for old browsers
+				  	video.src = window.URL.createObjectURL(stream);
+				}
 			})
 			.catch( function(err) {
 				// JH 2016-07-31 Instead of dispatching error, now falling back to Flash if userMedia fails (thx @john2014)


### PR DESCRIPTION
Internally webcam js library was using a deprecated method to store the stream object for playing video. Safari was not able to handle the exception. This fix modifies the condition and makes it cross browser compatible. Fixes #255.